### PR TITLE
Change how DC handles reference deletion and renaming

### DIFF
--- a/spine_items/data_connection/custom_file_system_watcher.py
+++ b/spine_items/data_connection/custom_file_system_watcher.py
@@ -74,6 +74,8 @@ class CustomFileSystemWatcher(QFileSystemWatcher):
                 self.file_added.emit(path)
         if not watched_files:
             del self._watched_files[dirname]
+            if dirname not in self._watched_dirs:
+                self.removePath(dirname)
 
     def add_persistent_file_path(self, path):
         if not os.path.isfile(path):

--- a/spine_items/data_connection/data_connection.py
+++ b/spine_items/data_connection/data_connection.py
@@ -26,7 +26,7 @@ from PySide2.QtWidgets import QFileDialog, QGraphicsItem, QFileIconProvider, QIn
 from spine_engine.utils.serialization import deserialize_path, serialize_path
 from spinetoolbox.project_item.project_item import ProjectItem
 from spinetoolbox.widgets.custom_qwidgets import ToolBarWidget
-from spinetoolbox.helpers import open_url
+from spinetoolbox.helpers import open_url, same_path
 from spinetoolbox.config import INVALID_FILENAME_CHARS
 from .commands import AddDCReferencesCommand, RemoveDCReferencesCommand, MoveReferenceToData
 from .custom_file_system_watcher import CustomFileSystemWatcher
@@ -280,7 +280,7 @@ class DataConnection(ProjectItem):
     def _remove_file_references(self, *refs):
         result = False
         for k in reversed(range(self._file_ref_root.rowCount())):
-            if any(_samepath(self._file_ref_root.child(k).text(), ref) for ref in refs):
+            if any(same_path(self._file_ref_root.child(k).text(), ref) for ref in refs):
                 self.file_references.pop(k)
                 self._file_ref_root.removeRow(k)
                 result = True
@@ -299,7 +299,7 @@ class DataConnection(ProjectItem):
     def _rename_file_reference(self, old_path, new_path):
         for k in range(self._file_ref_root.rowCount()):
             item = self._file_ref_root.child(k)
-            if _samepath(item.text(), old_path):
+            if same_path(item.text(), old_path):
                 item.setText(new_path)
                 self.file_references[k] = new_path
                 return True
@@ -308,7 +308,7 @@ class DataConnection(ProjectItem):
     def _remove_data_file(self, path):
         for k in reversed(range(self.data_model.rowCount())):
             data_filepath = self.data_model.item(k).data(_DATA_FILE_PATH_ROLE)
-            if _samepath(data_filepath, path):
+            if same_path(data_filepath, path):
                 self.data_model.removeRow(k)
                 return True
         return False
@@ -316,7 +316,7 @@ class DataConnection(ProjectItem):
     def _rename_data_file(self, old_path, new_path):
         for k in range(self.data_model.rowCount()):
             item = self.data_model.item(k)
-            if _samepath(item.data(_DATA_FILE_PATH_ROLE), old_path):
+            if same_path(item.data(_DATA_FILE_PATH_ROLE), old_path):
                 item.setText(os.path.basename(new_path))
                 item.setData(new_path, _DATA_FILE_PATH_ROLE)
                 return True
@@ -357,7 +357,7 @@ class DataConnection(ProjectItem):
 
     @Slot(str)
     def _handle_file_added(self, path):
-        if _samepath(os.path.dirname(path), self.data_dir):
+        if same_path(os.path.dirname(path), self.data_dir):
             self._append_data_files_to_model(path)
             self._check_notifications()
             self._resources_to_successors_changed()
@@ -623,7 +623,3 @@ class DataConnection(ProjectItem):
             self._logger.msg.emit("Link established")
         else:
             super().notify_destination(source_item)
-
-
-def _samepath(path1, path2):
-    return os.path.normcase(path1) == os.path.normcase(path2)

--- a/spine_items/data_connection/data_connection.py
+++ b/spine_items/data_connection/data_connection.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import logging
 from sqlalchemy import create_engine
-from PySide2.QtCore import Slot, Qt, QFileInfo, QModelIndex, QItemSelection
+from PySide2.QtCore import Slot, Qt, QFileInfo, QModelIndex, QItemSelection, QTimer
 from PySide2.QtGui import QStandardItem, QStandardItemModel, QBrush
 from PySide2.QtWidgets import QFileDialog, QGraphicsItem, QFileIconProvider, QInputDialog, QMessageBox
 from spine_engine.utils.serialization import deserialize_path, serialize_path
@@ -39,6 +39,9 @@ from ..utils import split_url_credentials
 
 _DATA_FILE_PATH_ROLE = Qt.UserRole + 1
 _MISSING_ROLE = Qt.UserRole + 2
+
+
+_MISSING_ITEM_FOREGROUND = QBrush(Qt.red)
 
 
 class DataConnection(ProjectItem):
@@ -296,15 +299,6 @@ class DataConnection(ProjectItem):
                 result = True
         return result
 
-    def _rename_file_reference(self, old_path, new_path):
-        for k in range(self._file_ref_root.rowCount()):
-            item = self._file_ref_root.child(k)
-            if same_path(item.text(), old_path):
-                item.setText(new_path)
-                self.file_references[k] = new_path
-                return True
-        return False
-
     def _remove_data_file(self, path):
         for k in reversed(range(self.data_model.rowCount())):
             data_filepath = self.data_model.item(k).data(_DATA_FILE_PATH_ROLE)
@@ -324,12 +318,41 @@ class DataConnection(ProjectItem):
 
     @Slot(str)
     def _handle_file_removed(self, path):
-        if self._remove_file_references(path) or self._remove_data_file(path):
+        """Marks file reference missing or removes data reference.
+
+        Args:
+            path (str): file path
+        """
+        resources_changed = self._try_to_mark_file_reference_missing(path) or self._remove_data_file(path)
+        if resources_changed:
             self._check_notifications()
             self._resources_to_successors_changed()
 
+    def _try_to_mark_file_reference_missing(self, path):
+        """Marks a file reference as missing if given path is in references.
+
+        Args:
+            path (str): file path
+
+        Returns:
+            bool: True if references was marked missing successfully, False otherwise
+        """
+        for row in range(self._file_ref_root.rowCount()):
+            item = self._file_ref_root.child(row)
+            if same_path(item.text(), path):
+                self._mark_as_missing(item)
+                return True
+        return False
+
     @Slot(str, str)
     def _handle_file_renamed(self, old_path, new_path):
+        """Marks file reference missing or renames data file.
+
+        Args:
+            old_path (str): original path
+            new_path (str): renamed path
+        """
+
         def replace_new_path(paths):
             for i, path in enumerate(paths):
                 if path == new_path:
@@ -337,10 +360,12 @@ class DataConnection(ProjectItem):
                     return True
             return False
 
-        renamed = self._rename_file_reference(old_path, new_path)
-        if not renamed:
-            renamed = self._rename_data_file(old_path, new_path)
-        if not renamed:
+        if self._try_to_mark_file_reference_missing(old_path):
+            self._refresh_file_reference_delayed(old_path)
+            self._check_notifications()
+            self._resources_to_successors_changed()
+            return
+        if not self._rename_data_file(old_path, new_path):
             return
         self._check_notifications()
         file_refs = list(self.file_references)
@@ -354,6 +379,36 @@ class DataConnection(ProjectItem):
             self, file_refs + data_files, self.db_references, self.db_credentials, self._project.project_dir
         )
         self._resources_to_successors_replaced(old_resources, new_resources)
+
+    def _refresh_file_reference_delayed(self, path):
+        """Checks if given file exists after certain delay.
+
+        Args:
+            path (str): file path
+        """
+        # Some software saves files by renaming them and then creating
+        # a new file with the same name for safety reasons.
+        # So, sometimes a file goes "missing" for a moment and then comes back.
+        # We'll try to refresh the file reference once in this case.
+        def refresh():
+            if not os.path.exists(path):
+                return
+            fixed_references = []
+            for row in range(self._file_ref_root.rowCount()):
+                item = self._file_ref_root.child(row, 0)
+                if not same_path(path, item.text()):
+                    continue
+                fixed_references.append(path)
+                item.clearData()
+                item.setFlags(~Qt.ItemIsEditable)
+                item.setData(path, Qt.DisplayRole)
+            if not fixed_references:
+                return
+            self.file_system_watcher.add_persistent_file_paths(ref for ref in fixed_references)
+            self._check_notifications()
+            self._resources_to_successors_changed()
+
+        QTimer.singleShot(1000, refresh)
 
     @Slot(str)
     def _handle_file_added(self, path):
@@ -521,16 +576,24 @@ class DataConnection(ProjectItem):
             item.setFlags(~Qt.ItemIsEditable)
             if not os.path.exists(path):
                 non_existent_paths.append(path)
-                tooltip = "The file is missing."
-                item.setData(tooltip, Qt.ToolTipRole)
-                item.setData(QBrush(Qt.red), Qt.ForegroundRole)
-                item.setData(True, _MISSING_ROLE)
+                self._mark_as_missing(item)
             self._file_ref_root.appendRow(item)
         if non_existent_paths:
             msg = f"<b>{self.name}:</b> Could not find file references:"
             for path in non_existent_paths:
                 msg += f"<br><b>{os.path.basename(path)}</b>"
             self._logger.msg_error.emit(msg)
+
+    @staticmethod
+    def _mark_as_missing(item):
+        """Modifies given model item to appear as missing reference.
+
+        Args:
+            item (QStandardItem): item to modify
+        """
+        item.setData("The file is missing.", Qt.ToolTipRole)
+        item.setData(_MISSING_ITEM_FOREGROUND, Qt.ForegroundRole)
+        item.setData(True, _MISSING_ROLE)
 
     def _append_db_references_to_model(self, *urls):
         for url in urls:

--- a/spine_items/data_connection/widgets/data_connection_properties_widget.py
+++ b/spine_items/data_connection/widgets/data_connection_properties_widget.py
@@ -102,5 +102,5 @@ class DataConnectionPropertiesWidget(PropertiesWidgetBase):
             dc.remove_files()
         elif option == "Open directory...":
             dc.open_directory()
-        elif option is not None:
+        elif option != "None":
             raise RuntimeError(f"Unknown menu option '{option}'")

--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -23,7 +23,7 @@ from copy import deepcopy
 from PySide2.QtGui import QStandardItemModel, QStandardItem, QTextDocument, QFont
 from PySide2.QtWidgets import QInputDialog, QFileDialog, QFileIconProvider, QMessageBox, QLabel
 from PySide2.QtCore import Slot, Qt, QFileInfo, QTimer, QItemSelection, QModelIndex
-from spinetoolbox.helpers import busy_effect, open_url
+from spinetoolbox.helpers import busy_effect, open_url, same_path
 from spinetoolbox.widgets.custom_qwidgets import ToolBarWidget
 from spinetoolbox.config import STATUSBAR_SS
 from spinetoolbox.project_item.specification_editor_window import (
@@ -656,7 +656,7 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
             old_program_files = [os.path.join(self.includes_main_path, f) for f in old_program_files]
         old_value = old_program_files[0] if old_program_files else ""
         if new_value is not None:  # Enables removing main program
-            if os.path.normcase(old_value) == os.path.normcase(new_value):
+            if same_path(old_value, new_value):
                 return
             new_program_files = old_program_files.copy()
             if new_program_files:
@@ -846,7 +846,7 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
                 continue
             if self.includes_main_path is not None:
                 common_prefix = os.path.commonprefix([os.path.abspath(self.includes_main_path), os.path.abspath(file)])
-                if os.path.normcase(common_prefix) != os.path.normcase(self.includes_main_path):
+                if not same_path(common_prefix, self.includes_main_path):
                     invalid.append(os.path.basename(file))
                     continue
             valid_files.append(file)


### PR DESCRIPTION
Previously we were renaming and removing Data connection's file references automatically bypassing the undo stack which led to situation where the file system watcher could modify the project but user couldn't undo, redo or even save the changes.

We now just mark deleted or renamed file references as "missing". This gives the user a proper heads-up that something is wrong and an option to e.g. refresh the references.

This also enables us to work around the disappearing Excel (and other software) files in a nice way: in case a file is renamed, we mark it as missing, but we automatically try to refresh the reference after 1s.

Fixes Spine-project/Spine-Toolbox#1691