### PR TITLE
Update copyright years in build_ui script

### DIFF
--- a/bin/append_license.py
+++ b/bin/append_license.py
@@ -5,7 +5,7 @@ import sys
 
 license_text = [
     "######################################################################################################################\n",
-    "# Copyright (C) 2017-2021 Spine project consortium\n",
+    "# Copyright (C) 2017-2022 Spine project consortium\n",
     "# This file is part of Spine Items.\n",
     "# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General\n",
     "# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)\n",

--- a/bin/build_ui.py
+++ b/bin/build_ui.py
@@ -57,7 +57,7 @@ def build_qrc(input_path, output_path, force):
 
 print(
     """<Script for Building Spine Items GUI>
-Copyright (C) <2017-2020>  <Spine project consortium>
+Copyright (C) <2017-2022>  <Spine project consortium>
 This program comes with ABSOLUTELY NO WARRANTY; for details see 'about'
 box in the application. This is free software, and you are welcome to
 redistribute it under certain conditions; See files COPYING and

--- a/bin/update_copyrights.py
+++ b/bin/update_copyrights.py
@@ -35,3 +35,5 @@ update_copyrights(root_dir, ".py", recursive=False)
 update_copyrights(project_source_dir, ".py")
 update_copyrights(project_source_dir, ".ui")
 update_copyrights(test_source_dir, ".py")
+
+print("Done. Don't forget to update append_license.py!")


### PR DESCRIPTION
Fixes the `build_ui` script that still used the ole copyright years 2017-2021.

Re Spine-project/Spine-Toolbox#1820

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
