### PR TITLE
Use attribute and item getters as sort keys

### DIFF
--- a/spine_items/exporter/exporter.py
+++ b/spine_items/exporter/exporter.py
@@ -17,6 +17,7 @@ Contains the :class:`Exporter` project item.
 """
 from dataclasses import dataclass
 from itertools import combinations, zip_longest
+from operator import itemgetter
 from pathlib import Path
 
 from PySide2.QtCore import Slot, Qt
@@ -230,7 +231,7 @@ class Exporter(ExporterBase):
     def item_dict(self):
         """See base class."""
         serialized = super().item_dict()
-        serialized["output_labels"] = sorted([c.to_dict() for c in self._output_channels], key=lambda d: d["in_label"])
+        serialized["output_labels"] = sorted([c.to_dict() for c in self._output_channels], key=itemgetter("in_label"))
         serialized["specification"] = self._specification_name
         return serialized
 

--- a/spine_items/exporter/mvcmodels/mapping_editor_table_model.py
+++ b/spine_items/exporter/mvcmodels/mapping_editor_table_model.py
@@ -15,6 +15,8 @@ Contains model for export mapping setup table.
 :date:   11.12.2020
 """
 from enum import IntEnum, unique
+from operator import itemgetter
+
 from PySide2.QtCore import QAbstractTableModel, QModelIndex, Qt
 from PySide2.QtGui import QFont, QColor
 from spinedb_api.mapping import is_pivoted, is_regular, Position, value_index
@@ -414,17 +416,17 @@ class MappingEditorTableModel(QAbstractTableModel):
             pivoted_mappings = [
                 (m.position, m) for row, m in enumerate(self._mappings) if is_pivoted(m.position) and row != value_row
             ]
-            pivoted_mappings.sort(reverse=True, key=lambda x: x[0])
+            pivoted_mappings.sort(reverse=True, key=itemgetter(0))
             for row, item in enumerate(pivoted_mappings):
                 item[1].position = -(row + 1)
             regular_mappings = [
                 (m.position, m) for row, m in enumerate(self._mappings) if is_regular(m.position) and row != value_row
             ]
-            last_column = max(regular_mappings, key=lambda x: x[0], default=-1)[0]
+            last_column = max(regular_mappings, key=itemgetter(0), default=-1)[0]
             regular_mappings.append((last_column + 1, self._mappings[value_row]))
         else:
             regular_mappings = [(m.position, m) for m in self._mappings if is_regular(m.position)]
-        regular_mappings.sort(key=lambda x: x[0])
+        regular_mappings.sort(key=itemgetter(0))
         for column, item in enumerate(regular_mappings):
             item[1].position = column
         top_left = self.index(0, EditorColumn.POSITION)

--- a/spine_items/exporter/mvcmodels/preview_tree_model.py
+++ b/spine_items/exporter/mvcmodels/preview_tree_model.py
@@ -15,6 +15,8 @@ Contains model for export preview tables.
 :date:   5.1.2021
 """
 from itertools import takewhile
+from operator import methodcaller
+
 from PySide2.QtCore import QAbstractItemModel, QModelIndex, Qt
 
 
@@ -41,7 +43,7 @@ class PreviewTreeModel(QAbstractItemModel):
         if mapping_name not in self._tables:
             new_names = list(self._mapping_names)
             new_names.append(mapping_name)
-            new_names.sort(key=lambda n: n.lower())
+            new_names.sort(key=methodcaller("lower"))
             row = len(list(takewhile(lambda x: x[0] == x[1], zip(new_names, self._mapping_names))))
             self.beginInsertRows(QModelIndex(), row, row)
             self._tables[mapping_name] = dict()
@@ -67,7 +69,7 @@ class PreviewTreeModel(QAbstractItemModel):
                 self._tables[mapping_name][name] = table
                 new_names = list(self._table_names[mapping_name])
                 new_names.append(name)
-                new_names.sort(key=lambda n: n.lower())
+                new_names.sort(key=methodcaller("lower"))
                 row = len(list(takewhile(lambda x: x[0] == x[1], zip(new_names, self._table_names[mapping_name]))))
                 self.beginInsertRows(parent_index, row, row)
                 self._table_names[mapping_name] = new_names
@@ -137,7 +139,7 @@ class PreviewTreeModel(QAbstractItemModel):
         Returns:
             tuple of str: old name, new name
         """
-        new_names = sorted(new_names, key=lambda n: n.lower())
+        new_names = sorted(new_names, key=methodcaller("lower"))
         olds = set(self._mapping_names)
         news = set(new_names)
         try:

--- a/spine_items/gdx_exporter/widgets/parameter_index_settings_window.py
+++ b/spine_items/gdx_exporter/widgets/parameter_index_settings_window.py
@@ -17,6 +17,8 @@ Parameter indexing settings window for .gdx export.
 """
 from contextlib import contextmanager
 from copy import deepcopy
+from operator import methodcaller
+
 from PySide2.QtCore import QItemSelectionModel, QModelIndex, Qt, Signal, Slot
 from PySide2.QtGui import QStandardItem
 from PySide2.QtWidgets import QMessageBox, QWidget
@@ -382,7 +384,7 @@ class ParameterIndexSettingsWindow(QWidget):
                     else:
                         item.setText(f"{parameter_name} {domain_names}")
             items.append(item)
-        for item in sorted(items, key=lambda i: i.text()):
+        for item in sorted(items, key=methodcaller("text")):
             model.appendRow(item)
 
     def _fix_legacy_indexing_settings(self, indexing_settings):

--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -20,6 +20,8 @@ is filled with all the information from the specification being edited.
 import logging
 import os
 from copy import deepcopy
+from operator import methodcaller
+
 from PySide2.QtGui import QStandardItemModel, QStandardItem, QTextDocument, QFont
 from PySide2.QtWidgets import QInputDialog, QFileDialog, QFileIconProvider, QMessageBox, QLabel
 from PySide2.QtCore import Slot, Qt, QFileInfo, QTimer, QItemSelection, QModelIndex
@@ -1172,9 +1174,9 @@ def _build_tree(root, components):
         else:
             item.setData(QFileIconProvider().icon(QFileInfo(parent)), Qt.DecorationRole)
             leafs.append(item)
-    for item in sorted(nodes, key=lambda x: x.text()):
+    for item in sorted(nodes, key=methodcaller("text")):
         root.appendRow(item)
-    for item in sorted(leafs, key=lambda x: x.text()):
+    for item in sorted(leafs, key=methodcaller("text")):
         root.appendRow(item)
 
 


### PR DESCRIPTION
No functional changes intended. Attribute and item getter provide slightly better performance over lambda.

Re Spine-project/Spine-Toolbox#1854

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
