### PR TITLE
Remove duplicate test functions and adapt tests for this

### DIFF
--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -16,12 +16,9 @@ Classes and functions that can be shared among unit test modules.
 :date:   30.9.2020
 """
 import os.path
-from unittest import mock
 from unittest.mock import MagicMock
 from PySide2.QtGui import QStandardItemModel
-from PySide2.QtWidgets import QWidget, QApplication
-import spine_items.resources_icons_rc  # pylint: disable=unused-import
-from spinetoolbox.ui_main import ToolboxUI
+from PySide2.QtWidgets import QWidget
 
 
 class MockQWidget(QWidget):
@@ -58,47 +55,3 @@ def mock_finish_project_item_construction(factory, project_item, mock_toolbox):
     project_item.set_properties_ui(properties_widget.ui)
     project_item.set_up()
     return properties_widget
-
-
-def create_toolboxui_with_project(project_dir):
-    """Returns ToolboxUI with a project instance where
-    QSettings among others has been mocked."""
-    with mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"), mock.patch(
-        "spinetoolbox.ui_main.ToolboxUI.update_recent_projects"
-    ), mock.patch("spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value, mock.patch(
-        "spinetoolbox.widgets.open_project_widget.OpenProjectDialog.update_recents"
-    ), mock.patch(
-        "spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"
-    ):
-        mock_qsettings_value.side_effect = qsettings_value_side_effect
-        toolbox = ToolboxUI()
-        toolbox.create_project("UnitTest Project", "Project for unit tests.", project_dir)
-    return toolbox
-
-
-def qsettings_value_side_effect(key, defaultValue="0"):
-    """Side effect for calling QSettings.value() method. Used to
-    override default value for key 'appSettings/openPreviousProject'
-    so that previous project is not opened in background when
-    ToolboxUI is instantiated.
-
-    Args:
-        key (str): Key to read
-        defaultValue (QVariant): Default value if key is missing
-    """
-    if key == "appSettings/openPreviousProject":
-        return "0"  # Do not open previous project when instantiating ToolboxUI
-    return defaultValue
-
-
-def clean_up_toolbox(toolbox):
-    """Cleans up toolbox and project."""
-    if toolbox.project():
-        toolbox.close_project(ask_confirmation=False)
-        QApplication.processEvents()  # Makes sure Design view animations finish properly.
-    toolbox.db_mngr.close_all_sessions()
-    toolbox.db_mngr.clean_up()
-    toolbox.db_mngr = None
-    # Delete undo stack explicitly to prevent emitting certain signals well after ToolboxUI has been destroyed.
-    toolbox.undo_stack.deleteLater()
-    toolbox.deleteLater()

--- a/tests/tool/widgets/test_toolSpecificationEditorWindow.py
+++ b/tests/tool/widgets/test_toolSpecificationEditorWindow.py
@@ -19,11 +19,12 @@ Unit tests for ToolSpecificationEditorWindow class.
 import unittest
 import logging
 import sys
-from tempfile import TemporaryDirectory, NamedTemporaryFile
+from unittest import mock
+from tempfile import NamedTemporaryFile
 from pathlib import Path
 from PySide2.QtWidgets import QApplication
 from spine_items.tool.widgets.tool_specification_editor_window import ToolSpecificationEditorWindow
-from tests.mock_helpers import create_toolboxui_with_project, clean_up_toolbox
+from tests.mock_helpers import create_mock_toolbox
 
 
 class TestToolSpecificationEditorWindow(unittest.TestCase):
@@ -43,9 +44,9 @@ class TestToolSpecificationEditorWindow(unittest.TestCase):
 
     def setUp(self):
         """Overridden method. Runs before each test."""
-        with TemporaryDirectory() as temp_dir:
-            self.toolbox = create_toolboxui_with_project(temp_dir)
-        self.tool_specification_widget = ToolSpecificationEditorWindow(self.toolbox)
+        self.toolbox = create_mock_toolbox()
+        with mock.patch("spinetoolbox.project_item.specification_editor_window.restore_ui"):
+            self.tool_specification_widget = ToolSpecificationEditorWindow(self.toolbox)
 
     def tearDown(self):
         """Overridden method. Runs after each test.
@@ -53,10 +54,8 @@ class TestToolSpecificationEditorWindow(unittest.TestCase):
         """
         self.tool_specification_widget.deleteLater()
         self.tool_specification_widget = None
-        clean_up_toolbox(self.toolbox)
 
     def test_create_minimal_julia_tool_specification(self):
-        """Test that a minimal Julia tool specification can be created by specifying name, type and main program file."""
         self.tool_specification_widget._ui.comboBox_tooltype.setCurrentIndex(0)  # 0: Julia
         self.tool_specification_widget._spec_toolbar._line_edit_name.setText("test_tool")
         with NamedTemporaryFile(mode="r") as temp_file:
@@ -64,7 +63,6 @@ class TestToolSpecificationEditorWindow(unittest.TestCase):
             self.tool_specification_widget._save()
 
     def test_create_minimal_gams_tool_specification(self):
-        """Test that a minimal Gams tool specification can be created by specifying name, type and main program file."""
         self.tool_specification_widget._ui.comboBox_tooltype.setCurrentIndex(2)  # 2: gams
         self.tool_specification_widget._spec_toolbar._line_edit_name.setText("test_tool")
         with NamedTemporaryFile(mode="r") as temp_file:
@@ -72,110 +70,109 @@ class TestToolSpecificationEditorWindow(unittest.TestCase):
             self.tool_specification_widget._save()
 
     def test_create_minimal_executable_tool_specification(self):
-        """Test that a minimal Executable tool specification can be created by specifying name, type and main program file."""
         self.tool_specification_widget._ui.comboBox_tooltype.setCurrentIndex(3)  # 3: executable
         self.tool_specification_widget._spec_toolbar._line_edit_name.setText("test_tool")
         with NamedTemporaryFile(mode="r") as temp_file:
             self.tool_specification_widget._set_main_program_file(str(Path(temp_file.name)))
             self.tool_specification_widget._save()
 
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_url_inputs(self):
-        self._test_add_cmdline_tag_on_empty_args_field("@@url_inputs@@")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_url_inputs_middle_of_other_tags(self):
-        self._test_add_cmdline_tag_middle_of_other_tags("@@url_inputs@@")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_url_inputs_no_space_before_regular_arg(self):
-        self._test_add_cmdline_tag_adds_no_space_before_regular_arg("@@url_inputs@@")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_url_outputs(self):
-        self._test_add_cmdline_tag_on_empty_args_field("@@url_outputs@@")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_url_outputs_middle_of_other_tags(self):
-        self._test_add_cmdline_tag_middle_of_other_tags("@@url_outputs@@")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_url_outputs_no_space_before_regular_arg(self):
-        self._test_add_cmdline_tag_adds_no_space_before_regular_arg("@@url_outputs@@")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_data_store_url(self):
-        self._test_add_cmdline_tag_on_empty_args_field("@@url:<data-store-name>@@")
-        selection = self.tool_specification_widget.ui.lineEdit_args.selectedText()
-        self.assertEqual(selection, "<data-store-name>")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_data_store_url_middle_of_other_tags(self):
-        self._test_add_cmdline_tag_middle_of_other_tags("@@url:<data-store-name>@@")
-        selection = self.tool_specification_widget.ui.lineEdit_args.selectedText()
-        self.assertEqual(selection, "<data-store-name>")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_data_store_url_no_space_before_regular_arg(self):
-        self._test_add_cmdline_tag_adds_no_space_before_regular_arg("@@url:<data-store-name>@@")
-        selection = self.tool_specification_widget.ui.lineEdit_args.selectedText()
-        self.assertEqual(selection, "<data-store-name>")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_optional_inputs(self):
-        self._test_add_cmdline_tag_on_empty_args_field("@@optional_inputs@@")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_optional_inputs_middle_of_other_tags(self):
-        self._test_add_cmdline_tag_middle_of_other_tags("@@optional_inputs@@")
-
-    @unittest.skip("Obsolete")
-    def test_add_cmdline_tag_optional_inputs_no_space_before_regular_arg(self):
-        self._test_add_cmdline_tag_adds_no_space_before_regular_arg("@@optional_inputs@@")
-
-    def _find_action(self, action_text, actions):
-        found_action = None
-        for action in actions:
-            if action.text() == action_text:
-                found_action = action
-                break
-        self.assertIsNotNone(found_action)
-        return found_action
-
-    def _test_add_cmdline_tag_on_empty_args_field(self, tag):
-        menu = self.tool_specification_widget.ui.toolButton_add_cmdline_tag.menu()
-        url_inputs_action = self._find_action(tag, menu.actions())
-        url_inputs_action.trigger()
-        args = self.tool_specification_widget.ui.lineEdit_args.text()
-        expected = tag + " "
-        self.assertEqual(args, expected)
-        if not self.tool_specification_widget.ui.lineEdit_args.hasSelectedText():
-            cursor_position = self.tool_specification_widget.ui.lineEdit_args.cursorPosition()
-            self.assertEqual(cursor_position, len(expected))
-
-    def _test_add_cmdline_tag_middle_of_other_tags(self, tag):
-        self.tool_specification_widget.ui.lineEdit_args.setText("@@optional_inputs@@@@url_outputs@@")
-        self.tool_specification_widget.ui.lineEdit_args.setCursorPosition(len("@@optional_inputs@@"))
-        menu = self.tool_specification_widget.ui.toolButton_add_cmdline_tag.menu()
-        url_inputs_action = self._find_action(tag, menu.actions())
-        url_inputs_action.trigger()
-        args = self.tool_specification_widget.ui.lineEdit_args.text()
-        self.assertEqual(args, f"@@optional_inputs@@ {tag} @@url_outputs@@")
-        if not self.tool_specification_widget.ui.lineEdit_args.hasSelectedText():
-            cursor_position = self.tool_specification_widget.ui.lineEdit_args.cursorPosition()
-            self.assertEqual(cursor_position, len(f"@@optional_inputs@@ {tag} "))
-
-    def _test_add_cmdline_tag_adds_no_space_before_regular_arg(self, tag):
-        self.tool_specification_widget.ui.lineEdit_args.setText("--tag=")
-        self.tool_specification_widget.ui.lineEdit_args.setCursorPosition(len("--tag="))
-        menu = self.tool_specification_widget.ui.toolButton_add_cmdline_tag.menu()
-        url_inputs_action = self._find_action(tag, menu.actions())
-        url_inputs_action.trigger()
-        args = self.tool_specification_widget.ui.lineEdit_args.text()
-        self.assertEqual(args, f"--tag={tag} ")
-        if not self.tool_specification_widget.ui.lineEdit_args.hasSelectedText():
-            cursor_position = self.tool_specification_widget.ui.lineEdit_args.cursorPosition()
-            self.assertEqual(cursor_position, len(f"--tag={tag} "))
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_url_inputs(self):
+    #     self._test_add_cmdline_tag_on_empty_args_field("@@url_inputs@@")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_url_inputs_middle_of_other_tags(self):
+    #     self._test_add_cmdline_tag_middle_of_other_tags("@@url_inputs@@")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_url_inputs_no_space_before_regular_arg(self):
+    #     self._test_add_cmdline_tag_adds_no_space_before_regular_arg("@@url_inputs@@")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_url_outputs(self):
+    #     self._test_add_cmdline_tag_on_empty_args_field("@@url_outputs@@")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_url_outputs_middle_of_other_tags(self):
+    #     self._test_add_cmdline_tag_middle_of_other_tags("@@url_outputs@@")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_url_outputs_no_space_before_regular_arg(self):
+    #     self._test_add_cmdline_tag_adds_no_space_before_regular_arg("@@url_outputs@@")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_data_store_url(self):
+    #     self._test_add_cmdline_tag_on_empty_args_field("@@url:<data-store-name>@@")
+    #     selection = self.tool_specification_widget.ui.lineEdit_args.selectedText()
+    #     self.assertEqual(selection, "<data-store-name>")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_data_store_url_middle_of_other_tags(self):
+    #     self._test_add_cmdline_tag_middle_of_other_tags("@@url:<data-store-name>@@")
+    #     selection = self.tool_specification_widget.ui.lineEdit_args.selectedText()
+    #     self.assertEqual(selection, "<data-store-name>")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_data_store_url_no_space_before_regular_arg(self):
+    #     self._test_add_cmdline_tag_adds_no_space_before_regular_arg("@@url:<data-store-name>@@")
+    #     selection = self.tool_specification_widget.ui.lineEdit_args.selectedText()
+    #     self.assertEqual(selection, "<data-store-name>")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_optional_inputs(self):
+    #     self._test_add_cmdline_tag_on_empty_args_field("@@optional_inputs@@")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_optional_inputs_middle_of_other_tags(self):
+    #     self._test_add_cmdline_tag_middle_of_other_tags("@@optional_inputs@@")
+    #
+    # @unittest.skip("Obsolete")
+    # def test_add_cmdline_tag_optional_inputs_no_space_before_regular_arg(self):
+    #     self._test_add_cmdline_tag_adds_no_space_before_regular_arg("@@optional_inputs@@")
+    #
+    # def _find_action(self, action_text, actions):
+    #     found_action = None
+    #     for action in actions:
+    #         if action.text() == action_text:
+    #             found_action = action
+    #             break
+    #     self.assertIsNotNone(found_action)
+    #     return found_action
+    #
+    # def _test_add_cmdline_tag_on_empty_args_field(self, tag):
+    #     menu = self.tool_specification_widget.ui.toolButton_add_cmdline_tag.menu()
+    #     url_inputs_action = self._find_action(tag, menu.actions())
+    #     url_inputs_action.trigger()
+    #     args = self.tool_specification_widget.ui.lineEdit_args.text()
+    #     expected = tag + " "
+    #     self.assertEqual(args, expected)
+    #     if not self.tool_specification_widget.ui.lineEdit_args.hasSelectedText():
+    #         cursor_position = self.tool_specification_widget.ui.lineEdit_args.cursorPosition()
+    #         self.assertEqual(cursor_position, len(expected))
+    #
+    # def _test_add_cmdline_tag_middle_of_other_tags(self, tag):
+    #     self.tool_specification_widget.ui.lineEdit_args.setText("@@optional_inputs@@@@url_outputs@@")
+    #     self.tool_specification_widget.ui.lineEdit_args.setCursorPosition(len("@@optional_inputs@@"))
+    #     menu = self.tool_specification_widget.ui.toolButton_add_cmdline_tag.menu()
+    #     url_inputs_action = self._find_action(tag, menu.actions())
+    #     url_inputs_action.trigger()
+    #     args = self.tool_specification_widget.ui.lineEdit_args.text()
+    #     self.assertEqual(args, f"@@optional_inputs@@ {tag} @@url_outputs@@")
+    #     if not self.tool_specification_widget.ui.lineEdit_args.hasSelectedText():
+    #         cursor_position = self.tool_specification_widget.ui.lineEdit_args.cursorPosition()
+    #         self.assertEqual(cursor_position, len(f"@@optional_inputs@@ {tag} "))
+    #
+    # def _test_add_cmdline_tag_adds_no_space_before_regular_arg(self, tag):
+    #     self.tool_specification_widget.ui.lineEdit_args.setText("--tag=")
+    #     self.tool_specification_widget.ui.lineEdit_args.setCursorPosition(len("--tag="))
+    #     menu = self.tool_specification_widget.ui.toolButton_add_cmdline_tag.menu()
+    #     url_inputs_action = self._find_action(tag, menu.actions())
+    #     url_inputs_action.trigger()
+    #     args = self.tool_specification_widget.ui.lineEdit_args.text()
+    #     self.assertEqual(args, f"--tag={tag} ")
+    #     if not self.tool_specification_widget.ui.lineEdit_args.hasSelectedText():
+    #         cursor_position = self.tool_specification_widget.ui.lineEdit_args.cursorPosition()
+    #         self.assertEqual(cursor_position, len(f"--tag={tag} "))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- The removed functions in mock_helpers.py were duplicates of the ones in spine toolbox tests. Removed these to minimize confusion.
- Commented some tests that were skipped as obsolete to prevent uninformative logging

No related issue.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
