### PR TITLE
Notify db committed from tools too

### DIFF
--- a/spine_items/db_writer_item_base.py
+++ b/spine_items/db_writer_item_base.py
@@ -1,0 +1,43 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Items.
+# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+"""
+Contains base classes for items that write to db.
+
+:authors: M. Marin (ER)
+:date:    23.9.2022
+"""
+from PySide2.QtCore import Slot
+from spinetoolbox.project_item.project_item import ProjectItem
+
+
+class DBWriterItemBase(ProjectItem):
+    """Base class for items that might write to a Spine DB."""
+
+    def successor_data_stores(self):
+        for name in self._project.successor_names(self.name):
+            item = self._project.get_item(name)
+            if item.item_type() == "Data Store":
+                yield item
+
+    @Slot(object, object)
+    def handle_execution_successful(self, execution_direction, engine_state):
+        """Notifies Toolbox of successful database import."""
+        if execution_direction != "FORWARD":
+            return
+        committed_db_maps = set()
+        for successor in self.successor_data_stores():
+            url = successor.sql_alchemy_url()
+            db_map = self._toolbox.db_mngr.db_map(url)
+            if db_map:
+                committed_db_maps.add(db_map)
+        if committed_db_maps:
+            self._toolbox.db_mngr.notify_session_committed(self, *committed_db_maps)

--- a/spine_items/importer/importer.py
+++ b/spine_items/importer/importer.py
@@ -22,15 +22,15 @@ from operator import itemgetter
 from PySide2.QtCore import QModelIndex, Qt, Slot
 
 from spinetoolbox.helpers import create_dir
-from spinetoolbox.project_item.project_item import ProjectItem
 from spinetoolbox.widgets.custom_menus import ItemSpecificationMenu
+from ..db_writer_item_base import DBWriterItemBase
 from ..commands import UpdateCancelOnErrorCommand, ChangeItemSelectionCommand, UpdateOnConflictCommand
 from ..models import CheckableFileListModel
 from .executable_item import ExecutableItem
 from .item_info import ItemInfo
 
 
-class Importer(ProjectItem):
+class Importer(DBWriterItemBase):
     def __init__(
         self,
         name,
@@ -91,22 +91,6 @@ class Importer(ProjectItem):
     @property
     def executable_class(self):
         return ExecutableItem
-
-    @Slot(object, object)
-    def handle_execution_successful(self, execution_direction, engine_state):
-        """Notifies Toolbox of successful database import."""
-        if execution_direction != "FORWARD":
-            return
-        successors = [self._project.get_item(name) for name in self._project.successor_names(self.name)]
-        committed_db_maps = set()
-        for successor in successors:
-            if successor.item_type() == "Data Store":
-                url = successor.sql_alchemy_url()
-                db_map = self._toolbox.db_mngr.db_map(url)
-                if db_map:
-                    committed_db_maps.add(db_map)
-        if committed_db_maps:
-            self._toolbox.db_mngr.notify_session_committed(self, *committed_db_maps)
 
     def make_signal_handler_dict(self):
         """Returns a dictionary of all shared signals and their handlers.
@@ -312,7 +296,7 @@ class Importer(ProjectItem):
     @staticmethod
     def from_dict(name, item_dict, toolbox, project):
         """See base class."""
-        description, x, y = ProjectItem.parse_item_dict(item_dict)
+        description, x, y = DBWriterItemBase.parse_item_dict(item_dict)
         specification_name = item_dict.get("specification", "")
         cancel_on_error = item_dict.get("cancel_on_error", False)
         on_conflict = item_dict.get("on_conflict", "merge")

--- a/spine_items/merger/merger.py
+++ b/spine_items/merger/merger.py
@@ -18,14 +18,14 @@ Module for Merger class.
 
 import os
 from PySide2.QtCore import Qt, Slot
-from spinetoolbox.project_item.project_item import ProjectItem
 from spinetoolbox.helpers import create_dir
 from ..commands import UpdateCancelOnErrorCommand
+from ..db_writer_item_base import DBWriterItemBase
 from .executable_item import ExecutableItem
 from .item_info import ItemInfo
 
 
-class Merger(ProjectItem):
+class Merger(DBWriterItemBase):
     def __init__(self, name, description, x, y, toolbox, project, cancel_on_error=False):
         """Data Store class.
 
@@ -98,26 +98,6 @@ class Merger(ProjectItem):
             if item.item_type() == "Data Store":
                 yield item
 
-    def successor_data_stores(self):
-        for name in self._project.successor_names(self.name):
-            item = self._project.get_item(name)
-            if item.item_type() == "Data Store":
-                yield item
-
-    @Slot(object, object)
-    def handle_execution_successful(self, execution_direction, engine_state):
-        """Notifies Toolbox of successful database import."""
-        if execution_direction != "FORWARD":
-            return
-        committed_db_maps = set()
-        for successor in self.successor_data_stores():
-            url = successor.sql_alchemy_url()
-            db_map = self._toolbox.db_mngr.db_map(url)
-            if db_map:
-                committed_db_maps.add(db_map)
-        if committed_db_maps:
-            self._toolbox.db_mngr.notify_session_committed(self, *committed_db_maps)
-
     def upstream_resources_updated(self, resources):
         self._check_notifications()
 
@@ -147,7 +127,7 @@ class Merger(ProjectItem):
     @staticmethod
     def from_dict(name, item_dict, toolbox, project):
         """See base class."""
-        description, x, y = ProjectItem.parse_item_dict(item_dict)
+        description, x, y = DBWriterItemBase.parse_item_dict(item_dict)
         cancel_on_error = item_dict.get("cancel_on_error", False)
         return Merger(name, description, x, y, toolbox, project, cancel_on_error)
 

--- a/spine_items/tool/tool.py
+++ b/spine_items/tool/tool.py
@@ -18,13 +18,13 @@ Tool class.
 import os
 from PySide2.QtCore import Slot, QItemSelection, Qt
 from PySide2.QtWidgets import QAction
-from spinetoolbox.project_item.project_item import ProjectItem
 from spinetoolbox.helpers import open_url
 from spinetoolbox.mvcmodels.file_list_models import FileListModel
 from spine_engine.config import TOOL_OUTPUT_DIR
 from spine_engine.project_item.project_item_resource import CmdLineArg, make_cmd_line_arg, LabelArg
 from spine_engine.utils.helpers import resolve_python_interpreter
 from .commands import UpdateToolExecuteInWorkCommand, UpdateToolOptionsCommand
+from ..db_writer_item_base import DBWriterItemBase
 from ..commands import UpdateCmdLineArgsCommand, UpdateGroupIdCommand
 from .item_info import ItemInfo
 from .widgets.custom_menus import ToolSpecificationMenu
@@ -35,7 +35,7 @@ from ..models import ToolCommandLineArgsModel
 from .output_resources import scan_for_resources
 
 
-class Tool(ProjectItem):
+class Tool(DBWriterItemBase):
     def __init__(
         self,
         name,
@@ -410,6 +410,7 @@ class Tool(ProjectItem):
 
     def handle_execution_successful(self, execution_direction, engine_state):
         """See base class."""
+        super().handle_execution_successful(execution_direction, engine_state)
         if execution_direction != "FORWARD":
             return
         self._resources_to_successors_changed()
@@ -493,7 +494,7 @@ class Tool(ProjectItem):
     @staticmethod
     def from_dict(name, item_dict, toolbox, project):
         """See base class."""
-        description, x, y = ProjectItem.parse_item_dict(item_dict)
+        description, x, y = DBWriterItemBase.parse_item_dict(item_dict)
         specification_name = item_dict.get("specification", "")
         execute_in_work = item_dict.get("execute_in_work", True)
         cmd_line_args = item_dict.get("cmd_line_args", [])


### PR DESCRIPTION
We need this so DB editors can refresh after a tool might write to them, same as Merger and Importer. Since we cannot control/know what the tool script does, we need to conservatively assume that it will write and commit to the DB.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
