### PR TITLE
Fix parallel Importers and Mergers

### DIFF
--- a/spine_items/data_transformer/executable_item.py
+++ b/spine_items/data_transformer/executable_item.py
@@ -55,17 +55,17 @@ class ExecutableItem(ExecutableItemBase):
             return False
         return True
 
-    def execute(self, forward_resources, backward_resources):
+    def execute(self, forward_resources, backward_resources, lock):
         """See base class."""
-        if not super().execute(forward_resources, backward_resources):
+        if not super().execute(forward_resources, backward_resources, lock):
             return ItemExecutionFinishState.FAILURE
         self._db_resources = [r for r in forward_resources if r.type_ == "database"]
         return ItemExecutionFinishState.SUCCESS
 
     # pylint: disable=no-self-use
-    def exclude_execution(self, forward_resources, backward_resources):
+    def exclude_execution(self, forward_resources, backward_resources, lock):
         """See base class."""
-        self.execute(forward_resources, backward_resources)
+        self.execute(forward_resources, backward_resources, lock)
 
     @classmethod
     def from_dict(cls, item_dict, name, project_dir, app_settings, specifications, logger):

--- a/spine_items/db_writer_executable_item_base.py
+++ b/spine_items/db_writer_executable_item_base.py
@@ -22,7 +22,7 @@ from spinedb_api.spine_db_client import SpineDBClient
 class DBWriterExecutableItemBase(ExecutableItemBase):
     """Base class for items that might write to a Spine DB."""
 
-    def exclude_execution(self, forward_resources, backward_resources):
+    def exclude_execution(self, forward_resources, backward_resources, lock):
         """Perform the checkout on output databases so concurrent items can proceed."""
         to_resources = [r for r in backward_resources if r.type_ == "database"]
         for resource in to_resources:

--- a/spine_items/exporter/executable_item.py
+++ b/spine_items/exporter/executable_item.py
@@ -98,9 +98,9 @@ class ExecutableItem(ExporterExecutableItemBase):
             channel.in_label = resource.label
         return channel
 
-    def execute(self, forward_resources, backward_resources):
+    def execute(self, forward_resources, backward_resources, lock):
         """See base class."""
-        status = super().execute(forward_resources, backward_resources)
+        status = super().execute(forward_resources, backward_resources, lock)
         if status != ItemExecutionFinishState.SUCCESS:
             return status
         if self._specification is None:

--- a/spine_items/exporter_executable_item_base.py
+++ b/spine_items/exporter_executable_item_base.py
@@ -60,7 +60,7 @@ class ExporterExecutableItemBase(ExecutableItemBase):
             self._process.terminate()
             self._process = None
 
-    def exclude_execution(self, forward_resources, backward_resources):
+    def exclude_execution(self, forward_resources, backward_resources, lock):
         """See base class."""
         manifest_file_name = (
             EXPORTER_EXECUTION_MANIFEST_FILE_PREFIX + (f"-{self.hash_filter_id()}" if self._filter_id else "")

--- a/spine_items/gdx_exporter/executable_item.py
+++ b/spine_items/gdx_exporter/executable_item.py
@@ -78,9 +78,9 @@ class ExecutableItem(ExporterExecutableItemBase):
             databases[full_url] = database.output_file_name
         return databases
 
-    def execute(self, forward_resources, backward_resources):
+    def execute(self, forward_resources, backward_resources, lock):
         """See base class."""
-        if not super().execute(forward_resources, backward_resources):
+        if not super().execute(forward_resources, backward_resources, lock):
             return ItemExecutionFinishState.FAILURE
         if self._settings_pack.settings is None:
             self._logger.msg_warning.emit(f"<b>{self.name}</b>: No export settings configured. Skipping.")

--- a/spine_items/gimlet/executable_item.py
+++ b/spine_items/gimlet/executable_item.py
@@ -100,9 +100,9 @@ class ExecutableItem(ExecutableItemBase):
             self._exec_mngr.stop_execution()
             self._exec_mngr = None
 
-    def execute(self, forward_resources, backward_resources):
+    def execute(self, forward_resources, backward_resources, lock):
         """See base class."""
-        if not super().execute(forward_resources, backward_resources):
+        if not super().execute(forward_resources, backward_resources, lock):
             return ItemExecutionFinishState.FAILURE
         if not self._work_dir:
             self._logger.msg_warning.emit("Work directory not set.")

--- a/spine_items/importer/do_work.py
+++ b/spine_items/importer/do_work.py
@@ -24,7 +24,7 @@ from spinedb_api.import_mapping.type_conversion import value_to_convert_spec
 from spine_engine.utils.helpers import create_log_file_timestamp
 
 
-def do_work(process, mapping, cancel_on_error, on_conflict, logs_dir, sources, connector, to_server_urls, logger):
+def do_work(process, mapping, cancel_on_error, on_conflict, logs_dir, sources, connector, to_server_urls, lock, logger):
     all_data = []
     all_errors = []
     table_mappings = {
@@ -88,12 +88,16 @@ def do_work(process, mapping, cancel_on_error, on_conflict, logs_dir, sources, c
                 all_errors.extend(errors)
         if all_data:
             for client in to_clients:
-                with process.maybe_idle:
-                    client.db_checkin()
-                success = _import_data_to_url(cancel_on_error, on_conflict, logs_dir, all_data, client, logger)
-                client.db_checkout()
-                if not success and cancel_on_error:
-                    return (False,)
+                lock.acquire()
+                try:
+                    with process.maybe_idle:
+                        client.db_checkin()
+                    success = _import_data_to_url(cancel_on_error, on_conflict, logs_dir, all_data, client, logger)
+                    client.db_checkout()
+                    if not success and cancel_on_error:
+                        return (False,)
+                finally:
+                    lock.release()
             all_data.clear()
     if all_errors:
         # Log errors in a time stamped file into the logs directory

--- a/spine_items/importer/executable_item.py
+++ b/spine_items/importer/executable_item.py
@@ -67,9 +67,9 @@ class ExecutableItem(DBWriterExecutableItemBase):
             self._process.terminate()
             self._process = None
 
-    def execute(self, forward_resources, backward_resources):
+    def execute(self, forward_resources, backward_resources, lock):
         """See base class."""
-        if not super().execute(forward_resources, backward_resources):
+        if not super().execute(forward_resources, backward_resources, lock):
             return ItemExecutionFinishState.FAILURE
         if not self._mapping:
             self._logger.msg_warning.emit(f"<b>{self.name}</b>: No mappings configured. Skipping.")
@@ -106,6 +106,7 @@ class ExecutableItem(DBWriterExecutableItemBase):
                     sources,
                     connector,
                     to_server_urls,
+                    lock,
                     self._logger,
                 ),
             )

--- a/spine_items/merger/do_work.py
+++ b/spine_items/merger/do_work.py
@@ -21,7 +21,7 @@ from spinedb_api.helpers import remove_credentials_from_url
 from spinedb_api.spine_db_client import SpineDBClient
 
 
-def do_work(process, cancel_on_error, logs_dir, from_server_urls, to_server_urls, logger):
+def do_work(process, cancel_on_error, logs_dir, from_server_urls, to_server_urls, lock, logger):
     from_clients = [SpineDBClient.from_server_url(server_url) for server_url in from_server_urls]
     from_url_export_data_response = [
         (from_client.get_db_url(), from_client.export_data()) for from_client in from_clients
@@ -35,28 +35,34 @@ def do_work(process, cancel_on_error, logs_dir, from_server_urls, to_server_urls
         with process.maybe_idle:
             to_client.db_checkin()
         for from_url, data in from_url_data:
-            response = to_client.import_data(data, "")
-            if "error" in response:
-                all_errors.append(response["error"])
-                continue
-            import_count, import_errors = response["result"]
-            all_errors += import_errors
-            if import_errors and cancel_on_error and import_count:
-                to_client.call_method("rollback_session")
-            else:
-                sanitized_from_url = remove_credentials_from_url(from_url)
-                sanitized_to_url = remove_credentials_from_url(to_client.get_db_url())
-                if data:
-                    to_client.call_method("commit_session", f"Import {import_count} items from {sanitized_from_url}")
-                    logger.msg_success.emit(
-                        "Merged {0} items with {1} errors from {2} into {3}".format(
-                            import_count, len(import_errors), sanitized_from_url, sanitized_to_url
-                        )
-                    )
+            lock.acquire()
+            try:
+                response = to_client.import_data(data, "")
+                if "error" in response:
+                    all_errors.append(response["error"])
+                    continue
+                import_count, import_errors = response["result"]
+                all_errors += import_errors
+                if import_errors and cancel_on_error and import_count:
+                    to_client.call_method("rollback_session")
                 else:
-                    logger.msg_warning.emit(
-                        "No new data merged from {0} into {1}".format(sanitized_from_url, sanitized_to_url)
-                    )
+                    sanitized_from_url = remove_credentials_from_url(from_url)
+                    sanitized_to_url = remove_credentials_from_url(to_client.get_db_url())
+                    if data:
+                        to_client.call_method(
+                            "commit_session", f"Import {import_count} items from {sanitized_from_url}"
+                        )
+                        logger.msg_success.emit(
+                            "Merged {0} items with {1} errors from {2} into {3}".format(
+                                import_count, len(import_errors), sanitized_from_url, sanitized_to_url
+                            )
+                        )
+                    else:
+                        logger.msg_warning.emit(
+                            "No new data merged from {0} into {1}".format(sanitized_from_url, sanitized_to_url)
+                        )
+            finally:
+                lock.release()
         to_client.db_checkout()
     if all_errors:
         # Log errors in a time stamped file into the logs directory

--- a/spine_items/tool/executable_item.py
+++ b/spine_items/tool/executable_item.py
@@ -400,7 +400,7 @@ class ExecutableItem(DBWriterExecutableItemBase):
                     return False
         return True
 
-    def execute(self, forward_resources, backward_resources):
+    def execute(self, forward_resources, backward_resources, lock):
         """See base class.
 
         Before launching the tool script in a separate instance,
@@ -408,7 +408,7 @@ class ExecutableItem(DBWriterExecutableItemBase):
         and copying input files where needed.
         After execution archives the output files.
         """
-        if not super().execute(forward_resources, backward_resources):
+        if not super().execute(forward_resources, backward_resources, lock):
             return ItemExecutionFinishState.FAILURE
         execution_dir = _execution_directory(self._work_dir, self._tool_specification)
         if execution_dir is None:
@@ -487,16 +487,16 @@ class ExecutableItem(DBWriterExecutableItemBase):
                     # Try again
                     self._retry_count += 1
                     self._logger.msg_warning.emit("The Tool process was found dead. Retrying...")
-                    return self.execute(forward_resources, backward_resources)
+                    return self.execute(forward_resources, backward_resources, lock)
                 self._logger.msg_warning.emit("Maximum amount of retries reached.")
         self._handle_output_files(return_code, self._filter_id, forward_resources, execution_dir)
         self._tool_instance = None
         # TODO: Check what return code is 'stopped' and return ItemExecutionFinishState.STOPPED in this case
         return ItemExecutionFinishState.SUCCESS if return_code == 0 else ItemExecutionFinishState.FAILURE
 
-    def exclude_execution(self, forward_resources, backward_resources):
+    def exclude_execution(self, forward_resources, backward_resources, lock):
         """See base class."""
-        super().exclude_execution(forward_resources, backward_resources)
+        super().exclude_execution(forward_resources, backward_resources, lock)
         if self._filter_id:
             self._output_dir = os.path.join(
                 self._output_dir, generate_filter_subdirectory_name(forward_resources, self.hash_filter_id())

--- a/tests/data_connection/test_DataConnection.py
+++ b/tests/data_connection/test_DataConnection.py
@@ -270,7 +270,9 @@ class TestDataConnection(unittest.TestCase):
             # Set index selected
             file_ref_root_index = self.ref_model.index(0, 0)
             ref_index = self.ref_model.index(0, 0, file_ref_root_index)
-            self.data_connection._properties_ui.treeView_dc_references.selectionModel().select(ref_index, QItemSelectionModel.Select)
+            self.data_connection._properties_ui.treeView_dc_references.selectionModel().select(
+                ref_index, QItemSelectionModel.Select
+            )
             indexes = self.data_connection._properties_ui.treeView_dc_references.selectedIndexes()
             self.assertTrue(len(indexes) == 1)
             self.data_connection._properties_ui.treeView_dc_references.del_key_pressed.emit()
@@ -278,8 +280,12 @@ class TestDataConnection(unittest.TestCase):
             # Remove remaining two simultaneously by selecting bith and removing them with delete key
             file_ref_index = self.ref_model.index(0, 0, self.ref_model.index(0, 0))
             db_ref_index = self.ref_model.index(0, 0, self.ref_model.index(1, 0))
-            self.data_connection._properties_ui.treeView_dc_references.selectionModel().select(file_ref_index, QItemSelectionModel.Select)
-            self.data_connection._properties_ui.treeView_dc_references.selectionModel().select(db_ref_index, QItemSelectionModel.Select)
+            self.data_connection._properties_ui.treeView_dc_references.selectionModel().select(
+                file_ref_index, QItemSelectionModel.Select
+            )
+            self.data_connection._properties_ui.treeView_dc_references.selectionModel().select(
+                db_ref_index, QItemSelectionModel.Select
+            )
             indexes = self.data_connection._properties_ui.treeView_dc_references.selectedIndexes()
             self.data_connection._properties_ui.treeView_dc_references.del_key_pressed.emit()
             self.assertEqual(0, len(self.data_connection.file_references))

--- a/tests/data_connection/test_DataConnectionExecutable.py
+++ b/tests/data_connection/test_DataConnectionExecutable.py
@@ -15,6 +15,7 @@ Unit tests for DataConnectionExecutable.
 :author: A. Soininen (VTT)
 :date:   6.4.2020
 """
+from multiprocessing import Lock
 import pathlib
 import tempfile
 import unittest
@@ -63,7 +64,7 @@ class TestDataConnectionExecutable(unittest.TestCase):
 
     def test_execute(self):
         executable = ExecutableItem("name", [], [], {}, self._temp_dir.name, mock.MagicMock())
-        self.assertTrue(executable.execute([], []))
+        self.assertTrue(executable.execute([], [], Lock()))
 
     def test_output_resources_backward(self):
         dc_data_dir = pathlib.Path(self._temp_dir.name, ".spinetoolbox", "items", "name")

--- a/tests/data_store/test_DataStoreExecutable.py
+++ b/tests/data_store/test_DataStoreExecutable.py
@@ -15,6 +15,7 @@ Unit tests for DataStoreExecutable.
 :author: A. Soininen
 :date:   6.4.2020
 """
+from multiprocessing import Lock
 from tempfile import TemporaryDirectory
 import unittest
 from unittest import mock
@@ -71,7 +72,7 @@ class TestDataStoreExecutable(unittest.TestCase):
 
     def test_execute(self):
         executable = ExecutableItem("name", "", self._temp_dir.name, mock.MagicMock())
-        self.assertTrue(executable.execute([], []))
+        self.assertTrue(executable.execute([], [], Lock()))
 
     def test_output_resources_backward(self):
         executable = ExecutableItem("name", "sqlite:///database.sqlite", self._temp_dir.name, mock.MagicMock())

--- a/tests/data_transformer/test_DataTransformerExecutable.py
+++ b/tests/data_transformer/test_DataTransformerExecutable.py
@@ -15,6 +15,7 @@ Contains unit tests for :class:`DataTransformerExecutable`.
 :authors: A. Soininen (VTT)
 :date:    7.1.2021
 """
+from multiprocessing import Lock
 from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import MagicMock
@@ -42,7 +43,7 @@ class TestDataTransformerExecutable(unittest.TestCase):
         logger = MagicMock()
         item = ExecutableItem("T", None, self._temp_dir.name, logger)
         db_resource = database_resource("provider", "sqlite:///db.sqlite")
-        self.assertTrue(item.execute([db_resource], []))
+        self.assertTrue(item.execute([db_resource], [], Lock()))
         expected_resource = database_resource(item.name, "sqlite:///db.sqlite")
         self.assertEqual(item.output_resources(ExecutionDirection.FORWARD), [expected_resource])
 
@@ -50,7 +51,7 @@ class TestDataTransformerExecutable(unittest.TestCase):
         logger = MagicMock()
         item = ExecutableItem("T", None, self._temp_dir.name, logger)
         db_resource = database_resource("provider", "sqlite:///db.sqlite")
-        item.exclude_execution([db_resource], [])
+        item.exclude_execution([db_resource], [], Lock())
         expected_resource = database_resource(item.name, "sqlite:///db.sqlite")
         self.assertEqual(item.output_resources(ExecutionDirection.FORWARD), [expected_resource])
 
@@ -60,7 +61,7 @@ class TestDataTransformerExecutable(unittest.TestCase):
         logger = MagicMock()
         transformer = ExecutableItem("T", specification, self._temp_dir.name, logger)
         db_resource = database_resource("provider", "sqlite:///db.sqlite")
-        self.assertTrue(transformer.execute([db_resource], []))
+        self.assertTrue(transformer.execute([db_resource], [], Lock()))
         filter_url = append_filter_config("sqlite:///db.sqlite", transformer._filter_config_path)
         expected_resource = database_resource(transformer.name, filter_url)
         self.assertEqual(transformer.output_resources(ExecutionDirection.FORWARD), [expected_resource])
@@ -71,7 +72,7 @@ class TestDataTransformerExecutable(unittest.TestCase):
         logger = MagicMock()
         transformer = ExecutableItem("T", specification, self._temp_dir.name, logger)
         db_resource = database_resource("provider", "sqlite:///db.sqlite")
-        transformer.exclude_execution([db_resource], [])
+        transformer.exclude_execution([db_resource], [], Lock())
         filter_url = append_filter_config("sqlite:///db.sqlite", transformer._filter_config_path)
         expected_resource = database_resource(transformer.name, filter_url)
         self.assertEqual(transformer.output_resources(ExecutionDirection.FORWARD), [expected_resource])

--- a/tests/gdx_exporter/test_GdxExporterExecutable.py
+++ b/tests/gdx_exporter/test_GdxExporterExecutable.py
@@ -15,7 +15,7 @@ Unit tests for :class:`ExporterExecutable`.
 :author: A. Soininen (VTT)
 :date:   6.4.2020
 """
-
+from multiprocessing import Lock
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -128,7 +128,7 @@ class TestGdxExporterExecutable(unittest.TestCase):
     @unittest.skipIf(gdx_utils.find_gams_directory() is None, "No working GAMS installation found.")
     def test_execute_no_output(self):
         executable = ExecutableItem("name", SettingsPack(), [], False, False, "", self._temp_dir.name, mock.MagicMock())
-        self.assertTrue(executable.execute([], []))
+        self.assertTrue(executable.execute([], [], Lock()))
 
     @unittest.skipIf(gdx_utils.find_gams_directory() is None, "No working GAMS installation found.")
     def test_execute_exports_simple_database_to_gdx(self):
@@ -153,7 +153,7 @@ class TestGdxExporterExecutable(unittest.TestCase):
         logger.__reduce__ = lambda _: (mock.MagicMock, ())
         executable = ExecutableItem("name", settings_pack, databases, False, False, "", self._temp_dir.name, logger)
         resources = [database_resource("provider", database_url)]
-        self.assertTrue(executable.execute(resources, []))
+        self.assertTrue(executable.execute(resources, [], Lock()))
         self.assertTrue(Path(executable._data_dir, "output.gdx").exists())
         gams_directory = gdx.find_gams_directory()
         with GdxFile(str(Path(executable._data_dir, "output.gdx")), "r", gams_directory) as gdx_file:

--- a/tests/gimlet/test_GimletExecutable.py
+++ b/tests/gimlet/test_GimletExecutable.py
@@ -15,6 +15,7 @@ Unit tests for Gimlet ExecutableItem.
 :author: P. Savolainen (VTT)
 :date:   25.5.2020
 """
+from multiprocessing import Lock
 import os
 import sys
 import unittest
@@ -106,14 +107,14 @@ class TestGimletExecutable(unittest.TestCase):
             expected_result = ItemExecutionFinishState.SUCCESS
         else:
             expected_result = ItemExecutionFinishState.FAILURE
-        self.assertEqual(expected_result, executable.execute([], []))
+        self.assertEqual(expected_result, executable.execute([], [], Lock()))
         # Test that bash shell execution works on Linux.
         executable = ExecutableItem("name", "bash", ["ls"], None, [], self._temp_dir.name, mock.MagicMock())
         if sys.platform == "linux":
             expected_result = ItemExecutionFinishState.SUCCESS
         else:
             expected_result = ItemExecutionFinishState.FAILURE
-        self.assertEqual(expected_result, executable.execute([], []))
+        self.assertEqual(expected_result, executable.execute([], [], Lock()))
 
     def test_output_resources_backward(self):
         executable = ExecutableItem("name", "cmd.exe", ["cd"], None, [], self._temp_dir.name, mock.MagicMock())

--- a/tests/importer/test_ImporterExecutable.py
+++ b/tests/importer/test_ImporterExecutable.py
@@ -15,6 +15,7 @@ Unit tests for ImporterExecutable.
 :authors: A. Soininen (VTT)
 :date:    6.4.2020
 """
+from multiprocessing import Lock
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -85,7 +86,7 @@ class TestImporterExecutable(unittest.TestCase):
 
     def test_execute_simplest_case(self):
         executable = ExecutableItem("name", {}, [], "", True, 'merge', self._temp_dir.name, mock.MagicMock())
-        self.assertTrue(executable.execute([], []))
+        self.assertTrue(executable.execute([], [], Lock()))
         # Check that _process is None after execution
         self.assertIsNone(executable._process)
 
@@ -107,7 +108,7 @@ class TestImporterExecutable(unittest.TestCase):
         with db_server_manager() as mngr_queue:
             for r in database_resources:
                 r.metadata["db_server_manager_queue"] = mngr_queue
-            self.assertTrue(executable.execute(file_resources, database_resources))
+            self.assertTrue(executable.execute(file_resources, database_resources, Lock()))
         # Check that _process is None after execution
         self.assertIsNone(executable._process)
         database_map = DatabaseMapping(database_url)
@@ -129,7 +130,7 @@ class TestImporterExecutable(unittest.TestCase):
         executable = ExecutableItem("name", {}, [], gams_path, True, 'merge', self._temp_dir.name, mock.MagicMock())
         database_resources = [database_resource("provider", database_url)]
         file_resources = [file_resource("provider", str(data_file))]
-        self.assertTrue(executable.execute(file_resources, database_resources))
+        self.assertTrue(executable.execute(file_resources, database_resources, Lock()))
         # Check that _process is None after execution
         self.assertIsNone(executable._process)
         database_map = DatabaseMapping(database_url)

--- a/tests/merger/test_MergerExecutable.py
+++ b/tests/merger/test_MergerExecutable.py
@@ -15,6 +15,7 @@ Unit tests for MergerExecutable.
 :author: A. Soininen
 :date:   6.4.2020
 """
+from multiprocessing import Lock
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -57,7 +58,7 @@ class TestMergerExecutable(unittest.TestCase):
 
     def test_execute(self):
         executable = ExecutableItem("name", True, self._temp_dir.name, mock.MagicMock())
-        self.assertTrue(executable.execute([], []))
+        self.assertTrue(executable.execute([], [], Lock()))
 
     def test_execute_merge_two_dbs(self):
         """Creates two db's with some data and merges them to a third db."""
@@ -92,7 +93,7 @@ class TestMergerExecutable(unittest.TestCase):
         with db_server_manager() as mngr_queue:
             for r in input_db_resources + output_db_resources:
                 r.metadata["db_server_manager_queue"] = mngr_queue
-            self.assertTrue(executable.execute(input_db_resources, output_db_resources))
+            self.assertTrue(executable.execute(input_db_resources, output_db_resources, Lock()))
         # Check output db
         output_db_map = DatabaseMapping(db3_url)
         class_list = output_db_map.object_class_list().all()

--- a/tests/tool/test_ToolExecutable.py
+++ b/tests/tool/test_ToolExecutable.py
@@ -15,6 +15,7 @@ Unit tests for ToolExecutable item.
 :author: A. Soininen (VTT)
 :date:   2.4.2020
 """
+from multiprocessing import Lock
 import sys
 import pathlib
 from tempfile import TemporaryDirectory
@@ -157,7 +158,7 @@ class TestToolExecutable(unittest.TestCase):
         executable = ExecutableItem(
             "Create files", str(work_dir), tool_specification, [], {}, None, self._temp_dir.name, logger
         )
-        executable.execute([], [])
+        executable.execute([], [], Lock())
         while executable._tool_instance is not None:
             QCoreApplication.processEvents()
         archives = list(pathlib.Path(executable._data_dir, "output").iterdir())

--- a/tests/view/test_ViewExecutable.py
+++ b/tests/view/test_ViewExecutable.py
@@ -15,6 +15,7 @@ Unit tests for ViewExecutable.
 :author: A. Soininen (VTT)
 :date:   6.4.2020
 """
+from multiprocessing import Lock
 from tempfile import TemporaryDirectory
 import unittest
 from unittest import mock
@@ -49,11 +50,11 @@ class TestViewExecutable(unittest.TestCase):
 
     def test_execute_backward(self):
         executable = ExecutableItem("name", self._temp_dir.name, mock.MagicMock())
-        self.assertTrue(executable.execute([], []))
+        self.assertTrue(executable.execute([], [], Lock()))
 
     def test_execute_forward(self):
         executable = ExecutableItem("name", self._temp_dir.name, mock.MagicMock())
-        self.assertTrue(executable.execute([], []))
+        self.assertTrue(executable.execute([], [], Lock()))
 
     def test_output_resources_backward(self):
         executable = ExecutableItem("name", self._temp_dir.name, mock.MagicMock())


### PR DESCRIPTION
Importer and Merger now utilize a shared to lock that prevents them from importing data into the same database at the same time.

Note the accompanying PR Spine-project/spine-engine#72

Fixes irena-flextool/flextool#30

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
~- [ ] Unit tests pass~ Won't pass due to changes in Spine Engine and executable item base class.
