### PR TITLE
Ensure that Data Store creates a new sqlite file before it is advertised

### DIFF
--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -150,13 +150,23 @@ class DataStore(ProjectItem):
         self.set_path_to_sqlite_file(file_path)
         return True
 
-    def _new_sqlite_file(self, checked=False):
+    def _new_sqlite_file(self):
+        """Shows a file dialog and creates a new sqlite file at the chosen path.
+
+        Returns:
+            bool: True if the file was created successfully, False otherwise
+        """
         candidate_path = os.path.abspath(os.path.join(self.data_dir, self.name + ".sqlite"))
         answer = QFileDialog.getSaveFileName(self._toolbox, "Create SQLite file", candidate_path)
         file_path = answer[0]
         if not file_path:  # Cancel button clicked
             return False
-        self.set_path_to_sqlite_file(file_path)
+        abs_path = os.path.abspath(file_path)
+        url = dict(self._url)
+        url["database"] = abs_path
+        sa_url = convert_to_sqlalchemy_url(url, self.name)
+        self._toolbox.db_mngr.create_new_spine_database(sa_url, self._logger)
+        self.update_url(dialect="sqlite", database=abs_path)
         return True
 
     def load_url_into_selections(self, url):
@@ -357,8 +367,8 @@ class DataStore(ProjectItem):
         if not sa_url:
             if self._url["dialect"] != "sqlite" or not self._new_sqlite_file():
                 return
-            sa_url = convert_to_sqlalchemy_url(self._url, self.name)
-        self._toolbox.db_mngr.create_new_spine_database(sa_url, self._logger)
+        else:
+            self._toolbox.db_mngr.create_new_spine_database(sa_url, self._logger)
         self._check_notifications()
 
     def _check_notifications(self):

--- a/tests/data_store/test_dataStore.py
+++ b/tests/data_store/test_dataStore.py
@@ -22,7 +22,7 @@ from unittest import mock
 import os
 import logging
 import sys
-from spinedb_api import create_new_spine_database
+from spinedb_api import create_new_spine_database, DatabaseMapping
 from spine_engine.project_item.project_item_resource import database_resource
 from PySide2.QtWidgets import QApplication
 import spine_items.resources_icons_rc  # pylint: disable=unused-import
@@ -144,6 +144,45 @@ class TestDataStore(unittest.TestCase):
         self.assertEqual("sqlite", cb_dialect.currentText())
         self.assertEqual(temp_path, le_db.text())
         self.assertTrue(os.path.exists(le_db.text()))
+
+    def test_new_database_is_created_before_advertising_resources(self):
+        self.ds.activate()
+        dialect_combo_box = self.ds_properties_ui.comboBox_dialect
+        dialect_combo_box.setCurrentText("sqlite")
+        self.assertEqual(dialect_combo_box.currentText(), "sqlite")
+        # Data store connects to combo box activated signal.
+        # We need to trigger the slot here manually.
+        self.ds.refresh_dialect(dialect_combo_box.currentText())
+        database_file_path = os.path.join(self._temp_dir.name, "test_db.sqlite")
+        failure_messages = []
+
+        def check_database_exists(data_store, for_successors):
+            if for_successors:
+                resources = data_store.resources_for_direct_successors()
+            else:
+                resources = data_store.resources_for_direct_predecessors()
+            if len(resources) != 1:
+                failure_messages.append("resources length is not equal to 1")
+                return
+            call_args = self.toolbox.db_mngr.create_new_spine_database.call_args
+            if len(call_args[0]) != 2:
+                failure_messages.append("call_args *args length is not equal to 2")
+                return
+            if str(call_args[0][0]) != resources[0].url:
+                failure_messages.append("create_new_spine_database() called with wrong URL")
+
+        with mock.patch("spine_items.data_store.data_store.QFileDialog") as file_dialog:
+            file_dialog.getSaveFileName.return_value = (database_file_path,)
+            self.project.notify_resource_changes_to_successors.side_effect = lambda item: check_database_exists(
+                item, True
+            )
+            self.project.notify_resource_changes_to_predecessors.side_effect = lambda item: check_database_exists(
+                item, False
+            )
+            self.assertTrue(self.ds_properties_ui.pushButton_create_new_spine_db.isEnabled())
+            self.ds_properties_ui.pushButton_create_new_spine_db.click()
+        if failure_messages:
+            self.fail(failure_messages[0])
 
     def test_save_and_restore_selections(self):
         """Test that selections are saved and restored when


### PR DESCRIPTION
Data Store now ensures the .sqlite file exists before the URL resource is broadcast. This prevents connections from failing to read scenarios/tools for filtering.

Fixes Spine-project/Spine-Toolbox#1925

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
