### PR TITLE
Fix Tool's optional input files

### DIFF
--- a/spine_items/tool/executable_item.py
+++ b/spine_items/tool/executable_item.py
@@ -578,7 +578,7 @@ class ExecutableItem(DBWriterExecutableItemBase):
             if not pattern:
                 # It's a directory -> skip
                 continue
-            found_files = _find_files_in_pattern(pattern, paths_in_resources)
+            found_files = _find_files_in_pattern(file_path, paths_in_resources)
             if not found_files:
                 self._logger.msg_warning.emit(f"\tNo files matching pattern <b>{pattern}</b> found")
             else:


### PR DESCRIPTION
This fixes a bug where Tool's optional input files would be copied to seemingly random input directories if more than one optional input file was given in the specification.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
