### PR TITLE
Improve candidate path guessing with New Spine db button

### DIFF
--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -171,7 +171,7 @@ class DataStore(ProjectItem):
             True if the file was created successfully, False otherwise
         """
         candidate_path = self._url["database"]
-        if not candidate_path or not os.path.exists(candidate_path):
+        if not candidate_path or not os.path.exists(os.path.dirname(candidate_path)):
             candidate_path = os.path.abspath(os.path.join(self.data_dir, self.name + ".sqlite"))
         answer = QFileDialog.getSaveFileName(self._toolbox, "Create SQLite file", candidate_path)
         file_path = answer[0]


### PR DESCRIPTION
It's OK if the candidate SQLite file doesn't exist, we care only about the path-to-the-file.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
